### PR TITLE
should wrap string constants in quotes when displaying/writing to file.

### DIFF
--- a/src/PHPExtensionStubGenerator/FilesDumper.php
+++ b/src/PHPExtensionStubGenerator/FilesDumper.php
@@ -97,7 +97,8 @@ class FilesDumper
                 $constName = $constant;
             }
 
-            $constantsFiles[$namespaceFilename] .= "const $constName = {$value};\n";
+            $encodeValue = is_string($value) ? sprintf('"%s"', $value) : $value;
+            $constantsFiles[$namespaceFilename] .= "const $constName = {$encodeValue};\n";
         }
 
         return $constantsFiles;

--- a/src/PHPExtensionStubGenerator/GeneratorDumper.php
+++ b/src/PHPExtensionStubGenerator/GeneratorDumper.php
@@ -68,9 +68,11 @@ class GeneratorDumper
                     yield "namespace {$namespace};";
                 }
 
-                yield "const $constName = {$value};";
+                $encodeValue = is_string($value) ? sprintf('"%s"', $value) : $value;
+                yield "const $constName = {$encodeValue};";
             } else {
-                yield "const $constant = {$value};";
+                $encodeValue = is_string($value) ? sprintf('"%s"', $value) : $value;
+                yield "const $constant = {$encodeValue};";
             }
         }
 


### PR DESCRIPTION
Before this PR, when I encounter string constants in my extension I get this in const.php:
```php
const SECP256K1_TYPE_CONTEXT = secp256k1_context;
const SECP256K1_TYPE_PUBKEY = secp256k1_pubkey;
// etc
```

This is syntactically wrong, and PHP7.2 reports that this will throw an Error in future versions of PHP. I realize stubs aren't executed, but still think this should be fixed.

Hope the PR is enough - it wraps all string constants as `"%s"` when displaying them. Afterwards:
```php
const SECP256K1_TYPE_CONTEXT = "secp256k1_context";
const SECP256K1_TYPE_PUBKEY = "secp256k1_pubkey";
```