### PR TITLE
Resource type doesn't get a parameter type hint

### DIFF
--- a/src/PHPExtensionStubGenerator/ZendCode/FunctionGenerator.php
+++ b/src/PHPExtensionStubGenerator/ZendCode/FunctionGenerator.php
@@ -20,9 +20,8 @@ class FunctionGenerator
         $line = 'function' . ' ' . $prototype['name'] . '(';
         $args = [];
         foreach ($prototype['arguments'] as $name => $argument) {
-            $argsLine = ($argument['type']
-                    ? $argument['type'] . ' '
-                    : '') . ($argument['by_ref'] ? '&' : '') . '$' . $name;
+            $type = ($argument['type'] && $argument['type'] !== 'resource') ? "{$argument['type']} " : "";
+            $argsLine = $type . ($argument['by_ref'] ? '&' : '') . '$' . $name;
             if (!$argument['required']) {
                 $argsLine .= ' = ' . var_export($argument['default'], true);
             }


### PR DESCRIPTION
If you use 'resource' PHP will think there's a class of that name.. Better to omit the parameter type